### PR TITLE
unittest: do not use `TestCase.debug` with `--pdb`

### DIFF
--- a/changelog/5991.bugfix.rst
+++ b/changelog/5991.bugfix.rst
@@ -1,0 +1,1 @@
+Do not use ``TestCase.debug()`` for unittests with ``--pdb``.

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -187,29 +187,8 @@ class TestCaseFunction(Function):
     def stopTest(self, testcase):
         pass
 
-    def _handle_skip(self):
-        # implements the skipping machinery (see #2137)
-        # analog to pythons Lib/unittest/case.py:run
-        testMethod = getattr(self._testcase, self._testcase._testMethodName)
-        if getattr(self._testcase.__class__, "__unittest_skip__", False) or getattr(
-            testMethod, "__unittest_skip__", False
-        ):
-            # If the class or method was skipped.
-            skip_why = getattr(
-                self._testcase.__class__, "__unittest_skip_why__", ""
-            ) or getattr(testMethod, "__unittest_skip_why__", "")
-            self._testcase._addSkip(self, self._testcase, skip_why)
-            return True
-        return False
-
     def runtest(self):
-        if self.config.pluginmanager.get_plugin("pdbinvoke") is None:
-            self._testcase(result=self)
-        else:
-            # disables tearDown and cleanups for post mortem debugging (see #1890)
-            if self._handle_skip():
-                return
-            self._testcase.debug()
+        self._testcase(result=self)
 
     def _prunetraceback(self, excinfo):
         Function._prunetraceback(self, excinfo)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -179,6 +179,7 @@ class TestPDB:
             child.wait()
         assert not child.isalive()
 
+    @pytest.mark.xfail(reason="running .debug() all the time is bad (#5991)")
     def test_pdb_unittest_postmortem(self, testdir):
         p1 = testdir.makepyfile(
             """
@@ -200,21 +201,37 @@ class TestPDB:
         self.flush(child)
 
     def test_pdb_unittest_skip(self, testdir):
-        """Test for issue #2137"""
+        """Test for issues #2137 and #5991"""
         p1 = testdir.makepyfile(
             """
             import unittest
+
             @unittest.skipIf(True, 'Skipping also with pdb active')
             class MyTestCase(unittest.TestCase):
                 def test_one(self):
                     assert 0
+
+            class MyOtherTestCase(unittest.TestCase):
+                def setUp(self):
+                    print("\\nsetUp_called\\n")
+
+                def tearDown(self):
+                    print("\\ntearDown_called\\n")
+
+                def test_two(self):
+                    self.skipTest("skip_two")
         """
         )
-        child = testdir.spawn_pytest("-rs --pdb %s" % p1)
-        child.expect("Skipping also with pdb active")
-        child.expect_exact("= \x1b[33m\x1b[1m1 skipped\x1b[0m\x1b[33m in")
-        child.sendeof()
-        self.flush(child)
+        result = testdir.runpytest("-s", "-rs", "--pdb", str(p1))
+        result.stdout.fnmatch_lines(
+            ["setUp_called", "tearDown_called", "*= 2 skipped in *"]
+        )
+        result.stdout.fnmatch_lines_random(
+            [
+                "SKIPPED [1] test_pdb_unittest_skip.py:5: Skipping also with pdb active",
+                "SKIPPED [1] test_pdb_unittest_skip.py:15: skip_two",
+            ]
+        )
 
     def test_pdb_print_captured_stdout_and_stderr(self, testdir):
         p1 = testdir.makepyfile(


### PR DESCRIPTION
Reverts https://github.com/pytest-dev/pytest/pull/1890, which needs to
be fixed/addressed in another way
(https://github.com/pytest-dev/pytest/pull/5996).

Fixes https://github.com/pytest-dev/pytest/issues/5991.

Ref: https://github.com/pytest-dev/pytest/pull/6014