### PR TITLE
pytester: use global monkeypatch fixture

### DIFF
--- a/src/_pytest/monkeypatch.py
+++ b/src/_pytest/monkeypatch.py
@@ -225,6 +225,7 @@ class MonkeyPatch:
         if name not in dic:
             if raising:
                 raise KeyError(name)
+            self._setitem.append((dic, name, notset))
         else:
             self._setitem.append((dic, name, dic.get(name, notset)))
             del dic[name]

--- a/testing/test_monkeypatch.py
+++ b/testing/test_monkeypatch.py
@@ -161,6 +161,14 @@ def test_delitem():
     assert d == {"hello": "world", "x": 1}
 
 
+def test_delitem_setitem_for_unknown():
+    from _pytest.monkeypatch import notset
+
+    monkeypatch = MonkeyPatch()
+    monkeypatch.delitem({}, "x", raising=False)
+    assert monkeypatch._setitem == [({}, "x", notset)]
+
+
 def test_setenv():
     monkeypatch = MonkeyPatch()
     with pytest.warns(pytest.PytestWarning):

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -565,17 +565,21 @@ def test_no_matching_after_match():
     assert str(e.value).splitlines() == ["fnmatch: '*'", "   with: '1'"]
 
 
-def test_pytester_addopts(request, monkeypatch):
+def test_pytester_addopts_before_testdir(request, monkeypatch):
+    orig = os.environ.get("PYTEST_ADDOPTS", None)
     monkeypatch.setenv("PYTEST_ADDOPTS", "--orig-unused")
-
     testdir = request.getfixturevalue("testdir")
+    assert "PYTEST_ADDOPTS" not in os.environ
+    testdir.finalize()
+    assert os.environ.get("PYTEST_ADDOPTS") == orig
 
-    try:
-        assert "PYTEST_ADDOPTS" not in os.environ
-    finally:
-        testdir.finalize()
 
-    assert os.environ["PYTEST_ADDOPTS"] == "--orig-unused"
+def test_testdir_respects_monkeypatch(testdir, monkeypatch):
+    assert monkeypatch is testdir.monkeypatch
+    assert testdir._env_run_update["COLUMNS"] == "80"
+    assert testdir._get_env_run_update()["COLUMNS"] == "80"
+    monkeypatch.setenv("COLUMNS", "12")
+    assert "COLUMNS" not in testdir._get_env_run_update()
 
 
 def test_run_stdin(testdir):

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -574,11 +574,18 @@ def test_pytester_addopts_before_testdir(request, monkeypatch):
     assert os.environ.get("PYTEST_ADDOPTS") == orig
 
 
-def test_testdir_respects_monkeypatch(testdir, monkeypatch):
+@pytest.mark.parametrize("method", ("setenv", "delenv"))
+def test_testdir_respects_monkeypatch(method, testdir, monkeypatch):
     assert monkeypatch is testdir.monkeypatch
     assert testdir._env_run_update["COLUMNS"] == "80"
     assert testdir._get_env_run_update()["COLUMNS"] == "80"
-    monkeypatch.setenv("COLUMNS", "12")
+    if method == "setenv":
+        monkeypatch.setenv("COLUMNS", "12")
+    else:
+        assert method == "delenv"
+        with pytest.raises(KeyError):
+            monkeypatch.delenv("COLUMNS")
+        monkeypatch.delenv("COLUMNS", raising=False)
     assert "COLUMNS" not in testdir._get_env_run_update()
 
 

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1951,6 +1951,7 @@ def test_sigwinch(testdir, monkeypatch):
         from _pytest.terminal import TerminalWriter
 
         def test(monkeypatch):
+            import os
             import signal
             import _pytest.terminal
 
@@ -1963,6 +1964,9 @@ def test_sigwinch(testdir, monkeypatch):
 
             _pytest.terminal._cached_terminal_width = None
             _pytest.terminal._cached_terminal_width_sighandler = None
+
+            # Outer monkeypatch is respected.
+            assert os.getenv("COLUMNS") == "50"
 
             tw = TerminalWriter()
             assert tw.fullwidth == 50


### PR DESCRIPTION
The update for inner runs then respects values being set there, e.g.
`COLUMNS`.

It also sets `COLUMNS` only for inner runs - otherwise the outer pytest's
`_write_progress_information_filling_space` would use the terminal width
from inner runs etc (since it is used before the teardown finalizer that
unsets it).