### PR TITLE
[WIP] -K to simply select/ignore cached nodeids

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -313,8 +313,6 @@ def pytest_ignore_collect(path, config):
     if not allow_in_venv and _in_venv(path):
         return True
 
-    return False
-
 
 def pytest_collection_modifyitems(items, config):
     deselect_prefixes = tuple(config.getoption("deselect") or [])


### PR DESCRIPTION
Uses `-K` since `-k` is meant to be kept compatible.

TODO:

- [ ] simple string-based query (with prefixes)?
- [ ] language/multiple args

For `pytest -K pdb --collect-only`:

No cache:

> 2596 deselected in 1.56s

Next run:

> 2596 deselected in 0.22s