### PR TITLE
LineMatcher: add LineMatcherFailed exception

### DIFF
--- a/changelog/6003.improvement.rst
+++ b/changelog/6003.improvement.rst
@@ -1,1 +1,0 @@
-Improve short excinfo with LineMatcher failures in short test summaries, via new ``OutcomeException.short_msg``.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 INSTALL_REQUIRES = [
     "py>=1.5.0",
     "packaging",
-    "attrs>=19.2.0",  # should match oldattrs tox env, bumped for kw_only.
+    "attrs>=17.4.0",  # should match oldattrs tox env.
     "more-itertools>=4.0.0",
     'atomicwrites>=1.0;sys_platform=="win32"',
     'pathlib2>=2.2.0;python_version<"3.6"',

--- a/src/_pytest/_code/code.py
+++ b/src/_pytest/_code/code.py
@@ -594,8 +594,7 @@ class ExceptionInfo(Generic[_E]):
         exconly = self.exconly(tryshort=True)
         entry = self.traceback.getcrashentry()
         path, lineno = entry.frame.code.raw.co_filename, entry.lineno
-        short_msg = getattr(self.value, "short_msg", None)
-        return ReprFileLocation(path, lineno + 1, exconly, short_msg=short_msg)
+        return ReprFileLocation(path, lineno + 1, exconly)
 
     def getrepr(
         self,
@@ -1110,14 +1109,11 @@ class ReprFileLocation(TerminalRepr):
     path = attr.ib(type=str)
     lineno = attr.ib(type=int)
     message = attr.ib(type=str)
-    short_msg = attr.ib(type=Optional[str], default=None, kw_only=True)
 
     def __attrs_post_init__(self):
         assert type(self.path) == str
 
     def _get_short_msg(self) -> str:
-        if self.short_msg:
-            return self.short_msg
         msg = self.message
         i = msg.find("\n")
         if i != -1:

--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -19,13 +19,7 @@ class OutcomeException(BaseException):
         contain info about test and collection outcomes.
     """
 
-    def __init__(
-        self,
-        msg: Optional[str] = None,
-        pytrace: bool = True,
-        *,
-        short_msg: Optional[str] = None
-    ) -> None:
+    def __init__(self, msg: Optional[str] = None, pytrace: bool = True,) -> None:
         if msg is not None and not isinstance(msg, str):
             error_msg = (
                 "{} expected string as 'msg' parameter, got '{}' instead.\n"
@@ -35,11 +29,8 @@ class OutcomeException(BaseException):
         BaseException.__init__(self, msg)
         self.msg = msg
         self.pytrace = pytrace
-        self.short_msg = short_msg
 
     def __repr__(self) -> str:
-        if self.short_msg:
-            return "<{} short_msg={!r}>".format(self.__class__.__name__, self.short_msg)
         msg = self.msg
         if msg:
             lines = msg.split("\n", maxsplit=1)
@@ -129,9 +120,7 @@ def skip(msg: str = "", *, allow_module_level: bool = False) -> "NoReturn":
 skip.Exception = Skipped  # type: ignore
 
 
-def fail(
-    msg: str = "", pytrace: bool = True, *, short_msg: Optional[str] = None
-) -> "NoReturn":
+def fail(msg: str = "", pytrace: bool = True) -> "NoReturn":
     """
     Explicitly fail an executing test with the given message.
 
@@ -140,7 +129,7 @@ def fail(
         python traceback will be reported.
     """
     __tracebackhide__ = True
-    raise Failed(msg=msg, pytrace=pytrace, short_msg=short_msg)
+    raise Failed(msg=msg, pytrace=pytrace)
 
 
 # Ignore type because of https://github.com/python/mypy/issues/2087.

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -1615,7 +1615,7 @@ class LineMatcher:
         __tracebackhide__ = True
         log_text = self._log_text
         self._log_output = []
-        pytest.fail(log_text, short_msg=msg)
+        pytest.fail("{}: Log:\n{}".format(msg, log_text), short_msg=msg)
 
     def str(self) -> str:
         """Return the entire original text."""

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -38,6 +38,7 @@ from _pytest.main import Session
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.nodes import Collector
 from _pytest.nodes import Item
+from _pytest.outcomes import Failed
 from _pytest.pathlib import Path
 from _pytest.python import Function
 from _pytest.python import Module
@@ -1409,6 +1410,18 @@ class LineComp:
         return LineMatcher(lines1).fnmatch_lines(lines2)
 
 
+# TODO: toterminal method that can apply colors?
+class LineMatcherFailed(Failed):
+    def __init__(self, *, msg: str, log_output: List[str]):
+        self._log_text = log_output
+        if log_output:
+            # TODO: info about (not) matched line number or similar?
+            #       It is good to have a newline after "Log:", but there
+            #       is much space there.  Maybe at least a "===" "heading"?
+            msg = "{}\nLog:\n{}".format(msg, "\n".join(log_output))
+        super().__init__(msg=msg)
+
+
 class LineMatcher:
     """Flexible matching of text.
 
@@ -1551,12 +1564,11 @@ class LineMatcher:
                     break
                 else:
                     if consecutive and started:
-                        msg = "no consecutive match: {!r}".format(line)
-                        self._log(msg)
-                        self._log(
-                            "{:>{width}}".format("with:", width=wnick), repr(nextline)
+                        self._fail(
+                            "no consecutive match: {!r} with {!r}".format(
+                                line, nextline,
+                            )
                         )
-                        self._fail(msg)
                     if not nomatchprinted:
                         self._log(
                             "{:>{width}}".format("nomatch:", width=wnick), repr(line)
@@ -1565,8 +1577,7 @@ class LineMatcher:
                     self._log("{:>{width}}".format("and:", width=wnick), repr(nextline))
                 extralines.append(nextline)
             else:
-                msg = "remains unmatched: {!r}".format(line)
-                self._log(msg)
+                msg = "unmatched: {!r}".format(line)
                 self._fail(msg)
         self._log_output = []
 
@@ -1600,10 +1611,7 @@ class LineMatcher:
         wnick = len(match_nickname) + 1
         for line in self.lines:
             if match_func(line, pat):
-                msg = "{}: {!r}".format(match_nickname, pat)
-                self._log(msg)
-                self._log("{:>{width}}".format("with:", width=wnick), repr(line))
-                self._fail(msg)
+                self._fail("{}: {!r} with {!r}".format(match_nickname, pat, line))
             else:
                 if not nomatch_printed:
                     self._log("{:>{width}}".format("nomatch:", width=wnick), repr(pat))
@@ -1613,9 +1621,9 @@ class LineMatcher:
 
     def _fail(self, msg: str) -> None:
         __tracebackhide__ = True
-        log_text = self._log_text
+        log_output = self._log_output
         self._log_output = []
-        pytest.fail("{}: Log:\n{}".format(msg, log_text), short_msg=msg)
+        raise LineMatcherFailed(msg=msg, log_output=log_output)
 
     def str(self) -> str:
         """Return the entire original text."""

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1259,15 +1259,9 @@ def _get_line_with_reprcrash_message(config, rep, termwidth):
             return line
 
     try:
-        msg = rep.longrepr.reprcrash.short_msg
-        assert msg is None or "\n" not in msg, repr(msg)
+        msg = rep.longrepr.reprcrash.message
     except AttributeError:
         msg = None
-    if msg is None:
-        try:
-            msg = rep.longrepr.reprcrash.message
-        except AttributeError:
-            msg = None
 
     if msg is not None:
         # Remove duplicate prefix, e.g. "Failed:" from pytest.fail.

--- a/testing/test_outcomes.py
+++ b/testing/test_outcomes.py
@@ -5,7 +5,3 @@ def test_OutcomeException():
     assert repr(OutcomeException()) == "<OutcomeException msg=None>"
     assert repr(OutcomeException(msg="msg")) == "<OutcomeException msg='msg'>"
     assert repr(OutcomeException(msg="msg\nline2")) == "<OutcomeException msg='msg...'>"
-    assert (
-        repr(OutcomeException(short_msg="short"))
-        == "<OutcomeException short_msg='short'>"
-    )

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -487,12 +487,13 @@ def test_linematcher_match_failure() -> None:
         lm.fnmatch_lines(["foo", "f*", "baz"])
     assert e.value.msg is not None
     assert e.value.msg.splitlines() == [
+        "unmatched: 'baz'",
+        "Log:",
         "exact match: 'foo'",
         "fnmatch: 'f*'",
         "   with: 'foo'",
         "nomatch: 'baz'",
         "    and: 'bar'",
-        "remains unmatched: 'baz'",
     ]
 
     lm = LineMatcher(["foo", "foo", "bar"])
@@ -500,12 +501,13 @@ def test_linematcher_match_failure() -> None:
         lm.re_match_lines(["foo", "^f.*", "baz"])
     assert e.value.msg is not None
     assert e.value.msg.splitlines() == [
+        "unmatched: 'baz'",
+        "Log:",
         "exact match: 'foo'",
         "re.match: '^f.*'",
         "    with: 'foo'",
         " nomatch: 'baz'",
         "     and: 'bar'",
-        "remains unmatched: 'baz'",
     ]
 
 
@@ -513,34 +515,40 @@ def test_linematcher_fnmatch_lines():
     lm = LineMatcher(["1", "2", "3"])
     with pytest.raises(pytest.fail.Exception) as excinfo:
         lm.fnmatch_lines(["2", "last_unmatched"])
-    assert excinfo.value.short_msg == "remains unmatched: 'last_unmatched'"
     assert str(excinfo.value).splitlines() == [
+        "unmatched: 'last_unmatched'",
+        "Log:",
         "nomatch: '2'",
         "    and: '1'",
         "exact match: '2'",
         "nomatch: 'last_unmatched'",
         "    and: '3'",
-        "remains unmatched: 'last_unmatched'",
     ]
 
 
 def test_linematcher_consecutive():
-    lm = LineMatcher(["1", "", "2"])
+    lm = LineMatcher(["1", "2", "other"])
+
+    lm.fnmatch_lines(["1", "*", "other"], consecutive=True)
     with pytest.raises(pytest.fail.Exception) as excinfo:
-        lm.fnmatch_lines(["1", "2"], consecutive=True)
+        lm.fnmatch_lines(["1", "*", "3"], consecutive=True)
     assert str(excinfo.value).splitlines() == [
+        "no consecutive match: '3' with 'other'",
+        "Log:",
         "exact match: '1'",
-        "no consecutive match: '2'",
-        "   with: ''",
+        "fnmatch: '*'",
+        "   with: '2'",
     ]
 
-    lm.re_match_lines(["1", r"\d?", "2"], consecutive=True)
+    lm.re_match_lines(["1", r"\d?", "other"], consecutive=True)
     with pytest.raises(pytest.fail.Exception) as excinfo:
-        lm.re_match_lines(["1", r"\d", "2"], consecutive=True)
+        lm.re_match_lines(["1", r"\d", r"\d"], consecutive=True)
     assert str(excinfo.value).splitlines() == [
+        r"no consecutive match: '\\d' with 'other'",
+        "Log:",
         "exact match: '1'",
-        r"no consecutive match: '\\d'",
-        "    with: ''",
+        "re.match: '\\\\d'",
+        "    with: '2'",
     ]
 
 
@@ -572,21 +580,25 @@ def test_linematcher_no_matching(function) -> None:
         obtained = str(e.value).splitlines()
         if function == "no_fnmatch_line":
             assert obtained == [
+                "fnmatch: '{}' with 'show_fixtures_per_test.py OK'".format(
+                    good_pattern
+                ),
+                "Log:",
                 "nomatch: '{}'".format(good_pattern),
                 "    and: 'cachedir: .pytest_cache'",
                 "    and: 'collecting ... collected 1 item'",
                 "    and: ''",
-                "fnmatch: '{}'".format(good_pattern),
-                "   with: 'show_fixtures_per_test.py OK'",
             ]
         else:
             assert obtained == [
+                "re.match: '{}' with 'show_fixtures_per_test.py OK'".format(
+                    good_pattern
+                ),
+                "Log:",
                 " nomatch: '{}'".format(good_pattern),
                 "     and: 'cachedir: .pytest_cache'",
                 "     and: 'collecting ... collected 1 item'",
                 "     and: ''",
-                "re.match: '{}'".format(good_pattern),
-                "    with: 'show_fixtures_per_test.py OK'",
             ]
 
     func = getattr(lm, function)
@@ -598,7 +610,16 @@ def test_linematcher_no_matching_after_match() -> None:
     lm.fnmatch_lines(["1", "3"])
     with pytest.raises(Failed) as e:
         lm.no_fnmatch_line("*")
-    assert str(e.value).splitlines() == ["fnmatch: '*'", "   with: '1'"]
+    assert str(e.value).splitlines() == ["fnmatch: '*' with '1'"]
+    with pytest.raises(Failed) as e:
+        lm.no_fnmatch_line("3")
+    assert str(e.value).splitlines() == [
+        "fnmatch: '3' with '3'",
+        "Log:",
+        "nomatch: '3'",
+        "    and: '1'",
+        "    and: '2'",
+    ]
 
 
 def test_pytester_addopts_before_testdir(request, monkeypatch) -> None:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -809,23 +809,27 @@ def test_fail_extra_reporting(tty, use_CI, testdir, monkeypatch, LineMatcher):
             "FAILED test_fail_extra_reporting.py:4::test_this - AssertionError: "
             + ("this_failed" * 8)
             + "\\nassert 0",
-            "FAILED test_fail_extra_reporting.py:9::test_linematcher - remains unmatched: 'last_unmatched'",
+            # TODO: no Log here?  (via tryshort?)
+            "FAILED test_fail_extra_reporting.py:9::test_linematcher"
+            " - LineMatcherFailed: unmatched: 'last_unmatched'"
+            "\\nLog:\\nnomatch: '2'\\n    and: '1'\\nexact match: '2'\\nnomatch: 'last_unmatched'\\n    and: '3'",
         ]
     else:
         msgs = [
             "FAILED test_fail_extra_reporting.py:4::test_this - AssertionError: this_faile...",
-            "FAILED test_fail_extra_reporting.py:9::test_linematcher - remains unmatched: ...",
+            "FAILED test_fail_extra_reporting.py:9::test_linematcher - LineMatcherFailed: ...",
         ]
 
     lm.fnmatch_lines(
         [
             '>       LineMatcher(["1", "2", "3"]).fnmatch_lines(["2", "last_unmatched"])',
-            "E       Failed: nomatch: '2'",
+            "E       LineMatcherFailed: unmatched: 'last_unmatched'",
+            "E       Log:",
+            "E       nomatch: '2'",
             "E           and: '1'",
             "E       exact match: '2'",
             "E       nomatch: 'last_unmatched'",
             "E           and: '3'",
-            "E       remains unmatched: 'last_unmatched'",
             "*test summary*",
         ]
         + msgs

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ setenv =
 extras = testing
 deps =
     doctesting: PyYAML
-    oldattrs: attrs==19.2.0
+    oldattrs: attrs==17.4.0
     oldattrs: hypothesis<=4.38.1
     numpy: numpy
     pexpect: pexpect


### PR DESCRIPTION
TODO:

- [x] remove `short_msg` workaround
- [ ] toterminal method that can apply colors? (revisit with new terminal formatting (changed in merge commit already))
- [ ] provide more info with "Log:" line (e.g. line number / offset(s))