### PR TITLE
assertrepr_compare: short with full diff

### DIFF
--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -137,20 +137,6 @@ def _gets_full_diff(op: str, left: Any, right: Any, verbose: int) -> bool:
 def assertrepr_compare(config, op: str, left: Any, right: Any) -> Optional[List[str]]:
     """Return specialised explanations for some operators/operands"""
     verbose = config.getoption("verbose")
-    if verbose > 1 and not _gets_full_diff(op, left, right, verbose):
-        left_repr = safeformat(left)
-        right_repr = safeformat(right)
-    else:
-        # XXX: "15 chars indentation" is wrong
-        #      ("E       AssertionError: assert "); should use term width.
-        maxsize = (
-            80 - 15 - len(op) - 2
-        ) // 2  # 15 chars indentation, 1 space around op
-        left_repr = saferepr(left, maxsize=maxsize)
-        right_repr = saferepr(right, maxsize=maxsize)
-
-    summary = "{} {} {}".format(left_repr, op, right_repr)
-
     explanation = None
     try:
         if op == "==":
@@ -168,6 +154,7 @@ def assertrepr_compare(config, op: str, left: Any, right: Any) -> Optional[List[
                     explanation = _compare_eq_cls(left, right, verbose, type_fn)
                 elif verbose > 0:
                     explanation = _compare_eq_verbose(left, right)
+
                 if isiterable(left) and isiterable(right):
                     expl = _compare_eq_iterable(left, right, verbose)
                     if explanation is not None:
@@ -189,6 +176,21 @@ def assertrepr_compare(config, op: str, left: Any, right: Any) -> Optional[List[
 
     if not explanation:
         return None
+
+    # Summary.
+    has_full_diff = "Full diff:" in explanation
+    if verbose > 1 and not has_full_diff:
+        left_repr = safeformat(left)
+        right_repr = safeformat(right)
+    else:
+        # XXX: "15 chars indentation" is wrong
+        #      ("E       AssertionError: assert "); should use term width.
+        maxsize = (
+            80 - 15 - len(op) - 2
+        ) // 2  # 15 chars indentation, 1 space around op
+        left_repr = saferepr(left, maxsize=maxsize)
+        right_repr = saferepr(right, maxsize=maxsize)
+    summary = "{} {} {}".format(left_repr, op, right_repr)
 
     return [summary] + explanation
 

--- a/src/_pytest/assertion/util.py
+++ b/src/_pytest/assertion/util.py
@@ -129,10 +129,15 @@ def isiterable(obj: Any) -> bool:
         return False
 
 
+def _gets_full_diff(op: str, left: Any, right: Any, verbose: int) -> bool:
+    # via _compare_eq_iterable
+    return verbose > 0 and op == "==" and isiterable(left) and isiterable(right)
+
+
 def assertrepr_compare(config, op: str, left: Any, right: Any) -> Optional[List[str]]:
     """Return specialised explanations for some operators/operands"""
     verbose = config.getoption("verbose")
-    if verbose > 1:
+    if verbose > 1 and not _gets_full_diff(op, left, right, verbose):
         left_repr = safeformat(left)
         right_repr = safeformat(right)
     else:
@@ -325,8 +330,11 @@ def _compare_eq_sequence(
 
             left_repr = repr(left_value)
             right_repr = repr(right_value)
-            gets_full_diff = verbose > 0  # via _compare_eq_iterable later.
-            if not gets_full_diff and len(left_repr) > 10 and len(right_repr) > 10:
+            if (
+                not _gets_full_diff("==", left, right, verbose)
+                and len(left_repr) > 10
+                and len(right_repr) > 10
+            ):
                 explanation += [
                     "At index {} diff:".format(i),
                     "{} !=".format(left_repr),

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -725,18 +725,28 @@ class TestAssert_reprcompare:
             def __repr__(self):
                 raise ValueError(42)
 
-        expl = callequal([], [A()])
-        assert "ValueError" in "".join(expl)
-        expl = callequal({}, {"1": A()}, verbose=2)
-        assert expl[0].startswith("{} == <[ValueError")
-        assert "raised in repr" in expl[0]
-        assert expl[1:] == [
+        expected_expl = [
             "(pytest_assertion plugin: representation of details failed:"
             " {}:{}: ValueError: 42.".format(
                 __file__, A.__repr__.__code__.co_firstlineno + 1
             ),
             " Probably an object has a faulty __repr__.)",
         ]
+
+        expl = callequal([], [A()])
+        assert expl[0].startswith("[] == [<[ValueError...")
+        assert "raised in repr" not in expl[0]
+
+        expl = callequal({}, {"1": A()}, verbose=1)
+        assert expl[0].startswith("{} == {'1': <[Value...")
+        assert "raised in repr" not in expl[0]
+        assert expl[1:] == expected_expl
+
+        # verbose=2 gets full repr with missing diff (because of crash).
+        expl = callequal({}, {"1": A()}, verbose=2)
+        assert expl[0].startswith("{} == <[ValueError")
+        assert "raised in repr" in expl[0]
+        assert expl[1:] == expected_expl
 
     def test_one_repr_empty(self):
         """


### PR DESCRIPTION
When using `-vv` it does not need to have the full formatted output at
the top (especially when it is long and not aligned/split by newlines),
if there is a full diff for it later anyway.

Factors out `_gets_full_diff`.