### PR TITLE
main(): handle `--fulltrace` with `UsageError`s

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -133,6 +133,10 @@ def main(args=None, plugins=None) -> Union[int, ExitCode]:
         tw = TerminalWriter(sys.stderr)
         for msg in e.args:
             tw.line("ERROR: {}\n".format(msg), red=True)
+        if "--fulltrace" in sys.argv or "--full-trace" in sys.argv:
+            import traceback
+
+            traceback.print_exc(file=sys.stderr)
         return ExitCode.USAGE_ERROR
 
 

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -104,9 +104,8 @@ def main(args=None, plugins=None) -> Union[int, ExitCode]:
             config = _prepareconfig(args, plugins)
         except ConftestImportFailure as e:
             exc_info = ExceptionInfo(e.excinfo)
-            tw = TerminalWriter(sys.stderr)
-            tw.line(
-                "ImportError while loading conftest '{e.path}'.".format(e=e), red=True
+            error = "{e.excinfo[0].__name__} while loading conftest '{e.path}'.".format(
+                e=e
             )
             exc_info.traceback = exc_info.traceback.filter(filter_traceback)
             exc_repr = (
@@ -115,9 +114,8 @@ def main(args=None, plugins=None) -> Union[int, ExitCode]:
                 else exc_info.exconly()
             )
             formatted_tb = str(exc_repr)
-            for line in formatted_tb.splitlines():
-                tw.line(line.rstrip(), red=True)
-            return ExitCode.USAGE_ERROR
+            error += "\n  " + "\n  ".join(formatted_tb.splitlines())
+            raise UsageError(error) from e.excinfo[1]
         else:
             try:
                 ret = config.hook.pytest_cmdline_main(

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -131,7 +131,8 @@ def main(args=None, plugins=None) -> Union[int, ExitCode]:
         tw = TerminalWriter(sys.stderr)
         for msg in e.args:
             tw.line("ERROR: {}\n".format(msg), red=True)
-        if "--fulltrace" in sys.argv or "--full-trace" in sys.argv:
+        args = sys.argv[1:] if args is None else args
+        if "--fulltrace" in args or "--full-trace" in args:
             import traceback
 
             traceback.print_exc(file=sys.stderr)

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -215,7 +215,7 @@ class TestGeneralUsage:
         )
 
     @pytest.mark.filterwarnings("default")
-    def test_better_reporting_on_conftest_load_failure(self, testdir):
+    def test_better_reporting_on_conftest_load_failure(self, testdir: "Testdir") -> None:
         """Show a user-friendly traceback on conftest import failures (#486, #3332)"""
         testdir.makepyfile("")
         conftest = testdir.makeconftest(
@@ -242,15 +242,17 @@ class TestGeneralUsage:
         assert "--version" in result.stdout.str()
         assert result.ret == 0
 
+        exc_name = MODULE_NOT_FOUND_ERROR
         result = testdir.runpytest()
         assert result.stdout.lines == []
         assert result.stderr.lines == [
             "ERROR: {} while loading conftest '{}'.".format(exc_name, conftest),
-            "conftest.py:3: in <module>",
-            "    foo()",
-            "conftest.py:2: in foo",
-            "    import qwerty",
-            "E   {}: No module named 'qwerty'".format(MODULE_NOT_FOUND_ERROR),
+            "  conftest.py:3: in <module>",
+            "      foo()",
+            "  conftest.py:2: in foo",
+            "      import qwerty",
+            "  E   {}: No module named 'qwerty'".format(exc_name),
+            "",
         ]
 
         result = testdir.runpytest_subprocess("--fulltrace")  # subprocess for sys.argv

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -270,7 +270,7 @@ class TestGeneralUsage:
                 "",
                 "During handling of the above exception, another exception occurred:",
                 "",
-                "ModuleNotFoundError: No module named 'qwerty'",
+                "{}: No module named 'qwerty'".format(exc_name),
                 "",
                 "The above exception was the direct cause of the following exception:",
                 "",

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1328,9 +1328,7 @@ def test_usageerror_with_fulltrace(testdir: "Testdir") -> None:
     assert result.stdout.lines == []
     assert result.ret == ExitCode.USAGE_ERROR
 
-    args = ["--fulltrace"]
-    testdir.monkeypatch.setattr(sys, "argv", [sys.executable] + args)
-    result = testdir.runpytest(args)
+    result = testdir.runpytest_subprocess("--fulltrace")  # subprocess for sys.argv
     assert result.stderr.lines[0:3] == [
         "ERROR: my_usageerror",
         "",

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1328,7 +1328,25 @@ def test_usageerror_with_fulltrace(testdir: "Testdir") -> None:
     assert result.stdout.lines == []
     assert result.ret == ExitCode.USAGE_ERROR
 
-    result = testdir.runpytest_subprocess("--fulltrace")  # subprocess for sys.argv
+    # Via sys.argv (subprocess).
+    result = testdir.runpytest_subprocess("--fulltrace")
+    assert result.stderr.lines[0:3] == [
+        "ERROR: my_usageerror",
+        "",
+        "Traceback (most recent call last):",
+    ]
+    result.stderr.fnmatch_lines(
+        [
+            "ERROR: my_usageerror",
+            "During handling of the above exception, another exception occurred:",
+            "_pytest.config.exceptions.UsageError: my_usageerror",
+        ]
+    )
+    assert result.stdout.lines == []
+    assert result.ret == ExitCode.USAGE_ERROR
+
+    # In-process (args to pytest.main).
+    result = testdir.runpytest_inprocess("--fulltrace")
     assert result.stderr.lines[0:3] == [
         "ERROR: my_usageerror",
         "",

--- a/testing/test_conftest.py
+++ b/testing/test_conftest.py
@@ -324,10 +324,11 @@ def test_no_conftest(testdir: Testdir) -> None:
     assert result.ret == ExitCode.NO_TESTS_COLLECTED
 
     expected_stderr = [
-        "ImportError while loading conftest '{}'.".format(conftest),
-        "conftest.py:1: in <module>",
-        "    assert 0",
-        "E   AssertionError: assert 0",
+        "ERROR: AssertionError while loading conftest '{}'.".format(conftest),
+        "  conftest.py:1: in <module>",
+        "      assert 0",
+        "  E   AssertionError: assert 0",
+        "",
     ]
     result = testdir.runpytest()
     assert result.ret == ExitCode.USAGE_ERROR


### PR DESCRIPTION
This uses `sys.argv` directly since no config is available there.

TODO:

- [ ] after config-refactor!?