### PR TITLE
pre-commit: black: --target-version py35

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
-        args: [--safe, --quiet]
+        args: [--safe, --quiet, --target-version, py35]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.0.0
     hooks:

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1141,7 +1141,7 @@ def fixture(
         params=params,
         autouse=autouse,
         ids=ids,
-        name=name
+        name=name,
     )
     scope = arguments.get("scope")
     params = arguments.get("params")
@@ -1179,7 +1179,7 @@ def yield_fixture(
         params=params,
         autouse=autouse,
         ids=ids,
-        name=name
+        name=name,
     )
 
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -439,7 +439,7 @@ class TestCaptureFixture:
                 out, err = capsys.readouterr()
                 assert out.startswith("42")
             """,
-            *opt
+            *opt,
         )
         reprec.assertoutcome(passed=1)
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -733,7 +733,7 @@ def test_plugin_loading_order(testdir):
                 config = session.config
                 terminal_plugin.append(bool(config.pluginmanager.get_plugin("terminalreporter")))
             """
-        }
+        },
     )
     testdir.syspathinsert()
     result = testdir.runpytest("-p", "myplugin", str(p1))
@@ -812,7 +812,7 @@ def test_config_in_subdirectory_colon_command_line_issue2148(testdir):
 
     testdir.makefile(
         ".ini",
-        **{"pytest": "[pytest]\nfoo = root", "subdir/pytest": "[pytest]\nfoo = subdir"}
+        **{"pytest": "[pytest]\nfoo = root", "subdir/pytest": "[pytest]\nfoo = subdir"},
     )
 
     testdir.makepyfile(


### PR DESCRIPTION
This is meant to avoid having trailing commas in function definitions,
which only works in Python 3.5.2+.

Ref: https://github.com/python/cpython/commit/df39599
Ref: https://github.com/pytest-dev/pytest/pull/6872