### PR TITLE
_mark_plugins_for_rewrite: use entrypoint module directly

### DIFF
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -27,6 +27,7 @@ from _pytest.assertion.util import (  # noqa: F401
     format_explanation as _format_explanation,
 )
 from _pytest.compat import fspath
+from _pytest.config import Config
 from _pytest.pathlib import fnmatch_ex
 from _pytest.pathlib import Path
 from _pytest.pathlib import PurePath
@@ -40,7 +41,7 @@ PYC_TAIL = "." + PYTEST_TAG + PYC_EXT
 class AssertionRewritingHook(importlib.abc.MetaPathFinder):
     """PEP302/PEP451 import hook which rewrites asserts."""
 
-    def __init__(self, config):
+    def __init__(self, config: Config) -> None:
         self.config = config
         try:
             self.fnpats = config.getini("python_files")
@@ -205,7 +206,7 @@ class AssertionRewritingHook(importlib.abc.MetaPathFinder):
 
         return self._is_marked_for_rewrite(name, state)
 
-    def _is_marked_for_rewrite(self, name: str, state):
+    def _is_marked_for_rewrite(self, name: str, state) -> bool:
         try:
             return self._marked_for_rewrite_cache[name]
         except KeyError:

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -668,69 +668,6 @@ class Notset:
 notset = Notset()
 
 
-def _iter_rewritable_modules(package_files):
-    """
-    Given an iterable of file names in a source distribution, return the "names" that should
-    be marked for assertion rewrite (for example the package "pytest_mock/__init__.py" should
-    be added as "pytest_mock" in the assertion rewrite mechanism.
-
-    This function has to deal with dist-info based distributions and egg based distributions
-    (which are still very much in use for "editable" installs).
-
-    Here are the file names as seen in a dist-info based distribution:
-
-        pytest_mock/__init__.py
-        pytest_mock/_version.py
-        pytest_mock/plugin.py
-        pytest_mock.egg-info/PKG-INFO
-
-    Here are the file names as seen in an egg based distribution:
-
-        src/pytest_mock/__init__.py
-        src/pytest_mock/_version.py
-        src/pytest_mock/plugin.py
-        src/pytest_mock.egg-info/PKG-INFO
-        LICENSE
-        setup.py
-
-    We have to take in account those two distribution flavors in order to determine which
-    names should be considered for assertion rewriting.
-
-    More information:
-        https://github.com/pytest-dev/pytest-mock/issues/167
-    """
-    package_files = list(package_files)
-    seen_some = False
-    for fn in package_files:
-        is_simple_module = "/" not in fn and fn.endswith(".py")
-        is_package = fn.count("/") == 1 and fn.endswith("__init__.py")
-        if is_simple_module:
-            module_name, _ = os.path.splitext(fn)
-            # we ignore "setup.py" at the root of the distribution
-            if module_name != "setup":
-                seen_some = True
-                yield module_name
-        elif is_package:
-            package_name = os.path.dirname(fn)
-            seen_some = True
-            yield package_name
-
-    if not seen_some:
-        # at this point we did not find any packages or modules suitable for assertion
-        # rewriting, so we try again by stripping the first path component (to account for
-        # "src" based source trees for example)
-        # this approach lets us have the common case continue to be fast, as egg-distributions
-        # are rarer
-        new_package_files = []
-        for fn in package_files:
-            parts = fn.split("/")
-            new_fn = "/".join(parts[1:])
-            if new_fn:
-                new_package_files.append(new_fn)
-        if new_package_files:
-            yield from _iter_rewritable_modules(new_package_files)
-
-
 class Config:
     """
     Access to configuration values, pluginmanager and plugin hooks.
@@ -948,15 +885,10 @@ class Config:
             # We don't autoload from setuptools entry points, no need to continue.
             return
 
-        package_files = (
-            str(file)
-            for dist in importlib_metadata.distributions()
-            if any(ep.group == "pytest11" for ep in dist.entry_points)
-            for file in dist.files or []
-        )
-
-        for name in _iter_rewritable_modules(package_files):
-            hook.mark_rewrite(name)
+        for dist in importlib_metadata.distributions():
+            for ep in dist.entry_points:
+                if ep.group == "pytest11":
+                    hook.mark_rewrite(ep.value)
 
     def _validate_args(self, args: List[str], via: str) -> List[str]:
         """Validate known args."""

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -873,7 +873,7 @@ class Config:
                 self._mark_plugins_for_rewrite(hook)
         _warn_about_missing_assertion(mode)
 
-    def _mark_plugins_for_rewrite(self, hook):
+    def _mark_plugins_for_rewrite(self, hook) -> None:
         """
         Given an importhook, mark for rewrite any top-level
         modules or packages in the distribution package for

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -887,8 +887,13 @@ class Config:
 
         for dist in importlib_metadata.distributions():
             for ep in dist.entry_points:
-                if ep.group == "pytest11":
-                    hook.mark_rewrite(ep.value)
+                if ep.group == "pytest11":  # type: ignore[attr-defined]
+                    top_level_lines = dist.read_text("top_level.txt")
+                    if top_level_lines:
+                        for top_level in top_level_lines.splitlines():
+                            hook.mark_rewrite(ep.value)
+                    else:
+                        hook.mark_rewrite(ep.value)
 
     def _validate_args(self, args: List[str], via: str) -> List[str]:
         """Validate known args."""

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -120,21 +120,15 @@ class TestGeneralUsage:
 
         loaded = []
 
-        @attr.s
-        class DummyEntryPoint:
-            name = attr.ib()
-            module = attr.ib()
-            group = "pytest11"
-
+        class DummyEntryPoint(importlib_metadata.EntryPoint):
             def load(self):
-                __import__(self.module)
                 loaded.append(self.name)
-                return sys.modules[self.module]
+                return super().load()
 
         entry_points = [
-            DummyEntryPoint("myplugin1", "mytestplugin1_module"),
-            DummyEntryPoint("myplugin2", "mytestplugin2_module"),
-            DummyEntryPoint("mycov", "mycov_module"),
+            DummyEntryPoint("myplugin1", "mytestplugin1_module", "pytest11"),
+            DummyEntryPoint("myplugin2", "mytestplugin2_module", "pytest11"),
+            DummyEntryPoint("mycov", "mycov_module", "pytest11"),
         ]
 
         @attr.s

--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -200,7 +200,7 @@ class TestImportHookInstallation:
 
             class DummyEntryPoint(object):
                 name = 'spam'
-                module_name = 'spam.py'
+                value = 'spamplugin'
                 group = 'pytest11'
 
                 def load(self):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -591,11 +591,7 @@ def test_options_on_small_file_do_not_blow_up(testdir):
 def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
 
-    class EntryPoint:
-        name = "mytestplugin"
-        group = "pytest11"
-        value = None
-
+    class EntryPoint(importlib_metadata.EntryPoint):
         def load(self):
             class PseudoPlugin:
                 x = 42
@@ -604,7 +600,7 @@ def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
 
     class Dist:
         files = ()
-        entry_points = (EntryPoint(),)
+        entry_points = (EntryPoint("mytestplugin", "mytestplugin", "pytest11"),)
 
     def my_dists():
         return (Dist,)
@@ -620,18 +616,14 @@ def test_preparse_ordering_with_setuptools(testdir, monkeypatch):
 def test_setuptools_importerror_issue1479(testdir, monkeypatch):
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
 
-    class DummyEntryPoint:
-        name = "mytestplugin"
-        group = "pytest11"
-        value = None
-
+    class EntryPoint(importlib_metadata.EntryPoint):
         def load(self):
             raise ImportError("Don't hide me!")
 
     class Distribution:
         version = "1.0"
         files = ("foo.txt",)
-        entry_points = (DummyEntryPoint(),)
+        entry_points = (EntryPoint("mytestplugin", "mytestplugin", "pytest11"),)
 
     def distributions():
         return (Distribution(),)
@@ -645,18 +637,14 @@ def test_importlib_metadata_broken_distribution(testdir, monkeypatch):
     """Integration test for broken distributions with 'files' metadata being None (#5389)"""
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
 
-    class DummyEntryPoint:
-        name = "mytestplugin"
-        group = "pytest11"
-        value = None
-
+    class EntryPoint(importlib_metadata.EntryPoint):
         def load(self):
             return object()
 
     class Distribution:
         version = "1.0"
         files = None
-        entry_points = (DummyEntryPoint(),)
+        entry_points = (EntryPoint("mytestplugin", "mytestplugin", "pytest11"),)
 
     def distributions():
         return (Distribution(),)
@@ -671,18 +659,14 @@ def test_plugin_preparse_prevents_setuptools_loading(testdir, monkeypatch, block
 
     plugin_module_placeholder = object()
 
-    class DummyEntryPoint:
-        name = "mytestplugin"
-        group = "pytest11"
-        value = None
-
+    class EntryPoint(importlib_metadata.EntryPoint):
         def load(self):
             return plugin_module_placeholder
 
     class Distribution:
         version = "1.0"
         files = ("foo.txt",)
-        entry_points = (DummyEntryPoint(),)
+        entry_points = (EntryPoint("mytestplugin", "mytestplugin", "pytest11"),)
 
     def distributions():
         return (Distribution(),)


### PR DESCRIPTION
This works around PytestAssertRewriteWarnings with namespace packages.

Ref: https://github.com/pytest-dev/pytest/pull/6313#issuecomment-573416757
Ref: https://github.com/pytest-dev/pytest/issues/2419

TODO:

- [ ] test / fix/improve