### PR TITLE
terminal: report non-entrypoint plugins (with verbose>=1)

### DIFF
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -320,6 +320,11 @@ class PytestPluginManager(PluginManager):
         # Used to know when we are importing conftests after the pytest_configure stage
         self._configured = False
 
+        if sys.version_info < (3, 6):
+            from ..compat import order_preserving_dict
+
+            self._name2plugin = order_preserving_dict()
+
     def parse_hookimpl_opts(self, plugin, name):
         # pytest hooks are always prefixed with pytest_
         # so we avoid accessing possibly non-readable attributes

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -806,7 +806,12 @@ class Config:
         plugins = attr.ib()
         dir = attr.ib(type=Path)
 
-    def __init__(self, pluginmanager, *, invocation_params=None) -> None:
+    def __init__(
+        self,
+        pluginmanager: PytestPluginManager,
+        *,
+        invocation_params: Optional[InvocationParams] = None
+    ) -> None:
         from .argparsing import Parser, FILE_OR_DIR
 
         if invocation_params is None:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -837,7 +837,7 @@ class TerminalReporter:
         result = [line]
 
         plugins = []
-        distplugins, otherplugins = get_plugin_info(
+        distplugins, otherplugins, _ = get_plugin_info(
             config, include_non_eps=config.option.verbose > 0
         )
         if distplugins:

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -154,9 +154,10 @@ class TestGeneralUsage:
             result.stderr.fnmatch_lines(
                 [
                     "setuptools registered plugins:",
-                    "  mpyproject-None at */mycov_module.py",
-                    "  mpyproject-None at */mytestplugin1_module.py",
-                    "  mpyproject-None at */mytestplugin2_module.py",
+                    "  mpyproject-None:",
+                    "    mycov at */mycov_module.py",
+                    "    myplugin1 at */mytestplugin1_module.py",
+                    "    myplugin2 at */mytestplugin2_module.py",
                 ]
             )
         else:
@@ -164,9 +165,10 @@ class TestGeneralUsage:
             result.stderr.fnmatch_lines(
                 [
                     "setuptools registered plugins:",
-                    "  mpyproject-None at */mytestplugin1_module.py",
-                    "  mpyproject-None at */mytestplugin2_module.py",
-                    "  mpyproject-None at */mycov_module.py",
+                    "  mpyproject-None:",
+                    "    myplugin1 at */mytestplugin1_module.py",
+                    "    myplugin2 at */mytestplugin2_module.py",
+                    "    mycov at */mycov_module.py",
                 ]
             )
         assert result.ret == 0

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -23,7 +23,7 @@ from _pytest.reports import TestReport
 from _pytest.terminal import _folded_skips
 from _pytest.terminal import _get_line_with_reprcrash_message
 from _pytest.terminal import _get_pos
-from _pytest.terminal import _plugin_nameversions
+from _pytest.terminal import get_plugin_info
 from _pytest.terminal import getreportopt
 from _pytest.terminal import TerminalReporter
 
@@ -73,10 +73,24 @@ def option(request):
     ],
     ids=["normal", "prefix-strip", "deduplicate"],
 )
-def test_plugin_nameversion(input, expected):
-    pluginlist = [(None, x) for x in input]
-    result = _plugin_nameversions(pluginlist)
-    assert result == expected
+def test__plugin_info(input: List[DistInfo], expected: List[str]):
+    class config:
+        invocation_dir = py.path.local()
+
+        class option:
+            verbose = 1
+
+        class pluginmanager:
+            @staticmethod
+            def list_plugin_distinfo():
+                return [(None, x) for x in input]
+
+            @staticmethod
+            def list_name_plugin():
+                return [(None, None) for x in input]
+
+    result = get_plugin_info(config)  # type: ignore[arg-type]
+    assert result == (expected, [])
 
 
 class TestTerminal:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -83,14 +83,14 @@ def test__plugin_info(input: List[DistInfo], expected: List[str]):
         class pluginmanager:
             @staticmethod
             def list_plugin_distinfo():
-                return [(None, x) for x in input]
+                return [(str(x), x) for x in input]
 
             @staticmethod
             def list_name_plugin():
-                return [(None, None) for x in input]
+                return [("ignored name", str(x)) for x in input]
 
     result = get_plugin_info(config)  # type: ignore[arg-type]
-    assert result == (expected, [])
+    assert result == (expected, [], [])
 
 
 class TestTerminal:


### PR DESCRIPTION
Via/inspired by https://github.com/blueyed/pytest/pull/328.

TODO:

- [x] refactor/use with --version output