### PR TITLE
Function: use `originalname` in `_getobj` and make it default to `name`

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1416,7 +1416,7 @@ class Function(PyobjMixin, nodes.Item):
         if callobj is not NOTSET:
             self.obj = callobj
 
-        #: original function name, without any decorations (for example
+        #: Original function name, without any decorations (for example
         #: parametrization adds a ``"[...]"`` suffix to function names).
         #:
         #: .. versionadded:: 3.0

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -1416,6 +1416,12 @@ class Function(PyobjMixin, nodes.Item):
         if callobj is not NOTSET:
             self.obj = callobj
 
+        #: original function name, without any decorations (for example
+        #: parametrization adds a ``"[...]"`` suffix to function names).
+        #:
+        #: .. versionadded:: 3.0
+        self.originalname = originalname if originalname is not None else name
+
         self.keywords.update(self.obj.__dict__)
         self.own_markers.extend(get_unpacked_marks(self.obj))
         if callspec:
@@ -1450,12 +1456,6 @@ class Function(PyobjMixin, nodes.Item):
         self.fixturenames = fixtureinfo.names_closure
         self._initrequest()
 
-        #: original function name, without any decorations (for example
-        #: parametrization adds a ``"[...]"`` suffix to function names).
-        #:
-        #: .. versionadded:: 3.0
-        self.originalname = originalname
-
     @classmethod
     def from_parent(cls, parent, **kw):  # todo: determine sound type limitations
         """
@@ -1473,11 +1473,7 @@ class Function(PyobjMixin, nodes.Item):
         return getimfunc(self.obj)
 
     def _getobj(self):
-        name = self.name
-        i = name.find("[")  # parametrization
-        if i != -1:
-            name = name[:i]
-        return getattr(self.parent.obj, name)
+        return getattr(self.parent.obj, self.originalname)
 
     @property
     def _pyfuncitem(self):

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -7,6 +7,7 @@ import pytest
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import ExitCode
 from _pytest.nodes import Collector
+from _pytest.pytester import Testdir
 
 if TYPE_CHECKING:
     from _pytest.pytester import Testdir
@@ -695,16 +696,39 @@ class TestFunction:
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(["* 3 passed in *"])
 
-    def test_function_original_name(self, testdir):
+    def test_function_originalname(self, testdir: Testdir) -> None:
         items = testdir.getitems(
             """
             import pytest
+
             @pytest.mark.parametrize('arg', [1,2])
             def test_func(arg):
                 pass
+
+            def test_no_param():
+                pass
         """
         )
-        assert [x.originalname for x in items] == ["test_func", "test_func"]
+        assert [x.originalname for x in items] == [
+            "test_func",
+            "test_func",
+            "test_no_param",
+        ]
+
+    def test_function_with_square_brackets(self, testdir: Testdir) -> None:
+        """Check that Function._getobj uses originalname."""
+        p1 = testdir.makepyfile(
+            """
+            locals()["test_foo[name]"] = lambda: None
+            """
+        )
+        result = testdir.runpytest("-v", str(p1))
+        result.stdout.fnmatch_lines(
+            [
+                "test_function_with_square_brackets.py::test_foo[[]name[]] PASSED *",
+                "*= 1 passed in *",
+            ]
+        )
 
 
 class TestSorting:

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -7,7 +7,6 @@ import pytest
 from _pytest.compat import TYPE_CHECKING
 from _pytest.config import ExitCode
 from _pytest.nodes import Collector
-from _pytest.pytester import Testdir
 
 if TYPE_CHECKING:
     from _pytest.pytester import Testdir
@@ -696,7 +695,7 @@ class TestFunction:
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(["* 3 passed in *"])
 
-    def test_function_originalname(self, testdir: Testdir) -> None:
+    def test_function_originalname(self, testdir: "Testdir") -> None:
         items = testdir.getitems(
             """
             import pytest
@@ -715,7 +714,7 @@ class TestFunction:
             "test_no_param",
         ]
 
-    def test_function_with_square_brackets(self, testdir: Testdir) -> None:
+    def test_function_with_square_brackets(self, testdir: "Testdir") -> None:
         """Check that Function._getobj uses originalname."""
         p1 = testdir.makepyfile(
             """


### PR DESCRIPTION
Ref: 1a79137d0 (added `originalname`, but only via `Metafunc._calls`)

Upstream: https://github.com/pytest-dev/pytest/commit/8b9b81c3c04399d0ebde8d85a9db60291b325acd (https://github.com/pytest-dev/pytest/pull/7035)