### PR TITLE
tests: fix TypeError with test_mark_closest

### DIFF
--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -316,8 +316,8 @@ class FuncFixtureInfo:
     # fixture names specified via usefixtures and via autouse=True in fixture
     # definitions.
     initialnames = attr.ib(type=tuple)
-    names_closure = attr.ib()  # List[str]
-    name2fixturedefs = attr.ib()  # List[str, List[FixtureDef]]
+    names_closure = attr.ib()  # type: List[str]
+    name2fixturedefs = attr.ib()  # type: List[str, List[FixtureDef]]
 
     def prune_dependency_tree(self):
         """Recompute names_closure from initialnames and name2fixturedefs

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -317,7 +317,7 @@ class FuncFixtureInfo:
     # definitions.
     initialnames = attr.ib(type=tuple)
     names_closure = attr.ib()  # type: List[str]
-    name2fixturedefs = attr.ib()  # type: List[str, List[FixtureDef]]
+    name2fixturedefs = attr.ib()  # type: Dict[str, List[FixtureDef]]
 
     def prune_dependency_tree(self):
         """Recompute names_closure from initialnames and name2fixturedefs

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -13,10 +13,14 @@ import attr
 from .._code.source import getfslineno
 from ..compat import ascii_escaped
 from ..compat import NOTSET
+from ..compat import TYPE_CHECKING
 from _pytest.outcomes import fail
 from _pytest.warning_types import PytestUnknownMarkWarning
 
 EMPTY_PARAMETERSET_OPTION = "empty_parameter_set_mark"
+
+if TYPE_CHECKING:
+    from typing import Dict
 
 
 def istestfunc(func):
@@ -148,9 +152,9 @@ class Mark:
     #: name of the mark
     name = attr.ib(type=str)
     #: positional arguments of the mark decorator
-    args = attr.ib()  # List[object]
+    args = attr.ib()  # type: List[object]
     #: keyword arguments of the mark decorator
-    kwargs = attr.ib()  # Dict[str, object]
+    kwargs = attr.ib()  # type: Dict[str, object]
 
     #: source Mark for ids with parametrize Marks
     _param_ids_from = attr.ib(type=Optional["Mark"], default=None, repr=False)

--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -21,6 +21,7 @@ EMPTY_PARAMETERSET_OPTION = "empty_parameter_set_mark"
 
 if TYPE_CHECKING:
     from typing import Dict
+    from typing import Tuple
 
 
 def istestfunc(func):
@@ -152,7 +153,7 @@ class Mark:
     #: name of the mark
     name = attr.ib(type=str)
     #: positional arguments of the mark decorator
-    args = attr.ib()  # type: List[object]
+    args = attr.ib()  # type: Tuple[object, ...]
     #: keyword arguments of the mark decorator
     kwargs = attr.ib()  # type: Dict[str, object]
 

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -279,7 +279,9 @@ class Node(metaclass=NodeMeta):
                 if name is None or getattr(mark, "name", None) == name:
                     yield node, mark
 
-    def get_closest_marker(self, name, default=None):
+    def get_closest_marker(
+        self, name: str, default: Optional[Mark] = None
+    ) -> Optional[Mark]:
         """return the first marker matching the name, from closest (for example function) to farther level (for example
         module level).
 

--- a/src/_pytest/pytester/__init__.py
+++ b/src/_pytest/pytester/__init__.py
@@ -978,7 +978,7 @@ class Testdir(Generic[AnyStr]):
         values = list(cmdlineargs) + [p]
         return self.inline_run(*values)
 
-    def inline_genitems(self, *args):
+    def inline_genitems(self, *args) -> "Tuple[List[Item], HookRecorder]":
         """Run ``pytest.main(['--collectonly'])`` in-process.
 
         Runs the :py:func:`pytest.main` function to run all of pytest inside

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -53,8 +53,8 @@ class TestCollector:
     def test_getparent(self, testdir):
         modcol = testdir.getmodulecol(
             """
-            class TestClass(object):
-                 def test_foo():
+            class TestClass:
+                 def test_foo(self):
                      pass
         """
         )

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -546,10 +546,10 @@ class TestFunctional:
             @pytest.mark.c(location="class")
             class Test:
                 @pytest.mark.c(location="function")
-                def test_has_own():
+                def test_has_own(self):
                     pass
 
-                def test_has_inherited():
+                def test_has_inherited(self):
                     pass
 
         """

--- a/testing/test_mark.py
+++ b/testing/test_mark.py
@@ -3,11 +3,15 @@ import sys
 from unittest import mock
 
 import pytest
+from _pytest.compat import TYPE_CHECKING
 from _pytest.config import ExitCode
 from _pytest.mark import EMPTY_PARAMETERSET_OPTION
 from _pytest.mark import MarkGenerator as Mark
 from _pytest.nodes import Collector
 from _pytest.nodes import Node
+
+if TYPE_CHECKING:
+    from _pytest.pytester import Testdir
 
 
 class TestMark:
@@ -538,7 +542,7 @@ class TestFunctional:
         items, rec = testdir.inline_genitems(p)
         self.assert_markers(items, test_foo=("a", "b", "c"), test_bar=("a", "b", "d"))
 
-    def test_mark_closest(self, testdir):
+    def test_mark_closest(self, testdir: "Testdir") -> None:
         p = testdir.makepyfile(
             """
             import pytest
@@ -551,13 +555,16 @@ class TestFunctional:
 
                 def test_has_inherited(self):
                     pass
-
         """
         )
         items, rec = testdir.inline_genitems(p)
         has_own, has_inherited = items
-        assert has_own.get_closest_marker("c").kwargs == {"location": "function"}
-        assert has_inherited.get_closest_marker("c").kwargs == {"location": "class"}
+        has_own_marker = has_own.get_closest_marker("c")
+        has_inherited_marker = has_inherited.get_closest_marker("c")
+        assert has_own_marker
+        assert has_inherited_marker
+        assert has_own_marker.kwargs == {"location": "function"}
+        assert has_inherited_marker.kwargs == {"location": "class"}
         assert has_own.get_closest_marker("missing") is None
 
     def test_mark_with_wrong_marker(self, testdir):


### PR DESCRIPTION
It fails when trying to run it actually:

> TypeError: test_has_inherited() takes 0 positional arguments but 1 was given

TODO:

- [ ] explicit test for current behavior with running it actually.