### PR TITLE
ci: GHA: do not use `-v`/`-vv` with outer runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,27 +66,21 @@ jobs:
           # Coverage for:
           # - osx
           # - pygments
-          # - verbosity=1
           - name: "macos-py36"
             python: "3.6"
             os: macos-latest
             tox_env: "py36-pygments-coverage"
-            pytest_addopts: "--verbosity=1"
 
           - name: "windows-py37 (1)"
             python: "3.7"
             os: windows-latest
             tox_env: "py37-coverage-grouped"
-            # Coverage for:
-            # - verbosity=2
-            pytest_addopts: "--verbosity=2 --test-group-count 2 --test-group=1"
+            pytest_addopts: "--test-group-count 2 --test-group=1"
           - name: "windows-py37 (2)"
             python: "3.7"
             os: windows-latest
             tox_env: "py37-coverage-grouped"
-            # Coverage for:
-            # - verbosity=2
-            pytest_addopts: "--verbosity=2 --test-group-count 2 --test-group=2"
+            pytest_addopts: "--test-group-count 2 --test-group=2"
 
           - name: "xdist"
             python: "3.8"


### PR DESCRIPTION
Coverage should get satisfied via tests using different verbosity themselves.