### PR TITLE
PytestDeprecationWarning for pytest.collect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
             # LsofFdLeakChecker itself.
             # (https://github.com/blueyed/pytest/issues/195)
             tox_env: "py38-lsof-pexpect-coverage"
-            pytest_addopts: "-m 'uses_pexpect or integration' --run-integration-tests"
+            pytest_addopts: "-m 'uses_pexpect or integration'"
             script_prefix: "env -u COLUMNS"
 
           # Coverage for:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       dist: trusty
       env:
         - TOXENV=py35-coverage
-        - PYTEST_ADDOPTS="-ra --durations=50 -m 'py35_specific or acceptance_tests'"
+        - PYTEST_ADDOPTS="-ra --durations=50 -m 'py35_specific or acceptance_tests or integration' --run-integration-tests"
       before_install:
         - python -m pip install -U pip==19.3.1
     # Coverage for Python 3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       dist: trusty
       env:
         - TOXENV=py35-coverage
-        - PYTEST_ADDOPTS="-ra --durations=50 -m 'py35_specific or acceptance_tests or integration' --run-integration-tests"
+        - PYTEST_ADDOPTS="-ra --durations=50 -m 'py35_specific or acceptance_tests or integration'"
       before_install:
         - python -m pip install -U pip==19.3.1
     # Coverage for Python 3.9

--- a/changelog/6981.deprecation.rst
+++ b/changelog/6981.deprecation.rst
@@ -1,0 +1,1 @@
+The forwarding attributes from `pytest.collect.X` (to `pytest.X`) are deprecated (`pytest.collect` was not a module since 3.0.7-161-gae234786e (in 2017) already).

--- a/src/_pytest/deprecated.py
+++ b/src/_pytest/deprecated.py
@@ -19,6 +19,12 @@ DEPRECATED_EXTERNAL_PLUGINS = {
     "pytest_faulthandler",
 }
 
+PYTEST_COLLECT_MODULE = UnformattedWarning(
+    PytestDeprecationWarning,
+    "pytest.collect.{name} was moved to pytest.{name}\n"
+    "Please update to the new name.",
+)
+
 FUNCARGNAMES = PytestDeprecationWarning(
     "The `funcargnames` attribute was an alias for `fixturenames`, "
     "since pytest 2.3 - use the newer attribute instead."

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 
 import pytest
+from _pytest.mark.legacy import matchmark
 from _pytest.pytester import RunResult
 
 
@@ -39,6 +40,11 @@ def pytest_runtest_setup(item):
     # "tests/test_foo.py::test_bar" with
     # "tests/test_foo.py" in invocation args.
     if any(item.nodeid == arg for arg in item.config.invocation_params.args):
+        return
+
+    # Run the test if selected by mark explicitly.
+    markexpr = item.config.option.markexpr
+    if markexpr and matchmark(item, markexpr):
         return
 
     pytest.skip("Not running {} test (use {})".format(mark, option))

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -5,6 +5,30 @@ from _pytest import deprecated
 from _pytest import nodes
 
 
+@pytest.mark.parametrize(
+    "attribute",
+    (
+        "Collector",
+        "Module",
+        "Function",
+        "Instance",
+        "Session",
+        "Item",
+        "Class",
+        "File",
+        "_fillfuncargs",
+    ),
+)
+def test_pytest_collect_module_deprecated(attribute: str) -> None:
+    msg = str(deprecated.PYTEST_COLLECT_MODULE.format(name=attribute))
+    with pytest.warns(DeprecationWarning, match=msg) as wr:
+        getattr(pytest.collect, attribute)
+    assert len(wr) == 1
+    assert wr[0].filename == __file__
+    f_lineno = inspect.currentframe().f_lineno  # type: ignore[union-attr]
+    assert wr[0].lineno == f_lineno - 3
+
+
 @pytest.mark.filterwarnings("default")
 def test_resultlog_is_deprecated(testdir):
     result = testdir.runpytest("--help")

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -37,7 +37,10 @@ def test_no_warnings(module: str) -> None:
     # fmt: on
 
 
-def test_pytest_collect_attribute(_sys_snapshot):
+@pytest.mark.filterwarnings(
+    "ignore:pytest.collect.Item was moved to pytest.Item:pytest.PytestDeprecationWarning",
+)
+def test_pytest_collect_attribute(_sys_snapshot) -> None:
     from types import ModuleType
 
     del sys.modules["pytest"]
@@ -45,17 +48,24 @@ def test_pytest_collect_attribute(_sys_snapshot):
     import pytest
 
     assert isinstance(pytest.collect, ModuleType)
-    assert pytest.collect.Item is pytest.Item
+    assert pytest.collect.Item is pytest.Item  # type: ignore[attr-defined]
 
     with pytest.raises(ImportError):
         import pytest.collect
 
+    from pytest import collect
+
+    with pytest.raises(AttributeError):
+        collect.doesnotexist  # type: ignore[attr-defined]
+
+
+def test_pytest___get_attr__(_sys_snapshot) -> None:
     if sys.version_info >= (3, 7):
         with pytest.raises(AttributeError, match=r"^doesnotexist$"):
             pytest.doesnotexist
     else:
         with pytest.raises(AttributeError, match=r"doesnotexist"):
-            pytest.doesnotexist
+            pytest.doesnotexist  # type: ignore[attr-defined]
 
 
 def test_pytest_circular_import(testdir: Testdir, symlink_or_skip) -> None:


### PR DESCRIPTION
Adopt `_pytest.deprecated.PYTEST_COLLECT_MODULE` from f1d51ba1f.