### PR TITLE
Stop using more-itertools

### DIFF
--- a/changelog/7587.trivial.rst
+++ b/changelog/7587.trivial.rst
@@ -1,0 +1,1 @@
+The dependency on the ``more-itertools`` package has been removed.

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1,6 +1,5 @@
 import functools
 import inspect
-import itertools
 import sys
 import warnings
 from collections import defaultdict
@@ -1305,10 +1304,10 @@ class FixtureManager:
         else:
             argnames = ()
 
-        usefixtures = itertools.chain.from_iterable(
-            mark.args for mark in node.iter_markers(name="usefixtures")
+        usefixtures = tuple(
+            arg for mark in node.iter_markers(name="usefixtures") for arg in mark.args
         )
-        initialnames = tuple(usefixtures) + argnames
+        initialnames = usefixtures + argnames
         fm = node.session._fixturemanager
         initialnames, names_closure, arg2fixturedefs = fm.getfixtureclosure(
             initialnames, node, ignore_args=self._get_direct_parametrize_args(node)

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -17,6 +17,7 @@ from typing import TypeVar
 from typing import Union
 
 import _pytest._code
+from .types import validate_tup_type
 from _pytest.compat import overload
 from _pytest.compat import STRING_TYPES
 from _pytest.compat import TYPE_CHECKING
@@ -671,15 +672,7 @@ def raises(  # noqa: F811
     """
     __tracebackhide__ = True
 
-    if isinstance(expected_exception, type):
-        excepted_exceptions = (expected_exception,)  # type: Tuple[Type[_E], ...]
-    else:
-        excepted_exceptions = expected_exception
-    for exc in excepted_exceptions:
-        if not isinstance(exc, type) or not issubclass(exc, BaseException):
-            msg = "expected exception must be a BaseException type, not {}"
-            not_a = exc.__name__ if isinstance(exc, type) else type(exc).__name__
-            raise TypeError(msg.format(not_a))
+    validate_tup_type(expected_exception, BaseException)
 
     message = "DID NOT RAISE {}".format(expected_exception)
 

--- a/src/_pytest/python_api.py
+++ b/src/_pytest/python_api.py
@@ -1,11 +1,9 @@
-import inspect
 import math
 import pprint
 from collections.abc import Iterable
 from collections.abc import Mapping
 from collections.abc import Sized
 from decimal import Decimal
-from itertools import filterfalse
 from numbers import Number
 from types import TracebackType
 from typing import Any
@@ -18,8 +16,6 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-from more_itertools.more import always_iterable
-
 import _pytest._code
 from _pytest.compat import overload
 from _pytest.compat import STRING_TYPES
@@ -28,9 +24,6 @@ from _pytest.outcomes import fail
 
 if TYPE_CHECKING:
     from typing import Type  # noqa: F401 (used in type string)
-
-
-BASE_TYPE = (type, STRING_TYPES)
 
 
 def _non_numeric_type_error(value, at):
@@ -677,11 +670,16 @@ def raises(  # noqa: F811
         documentation for :ref:`the try statement <python:try>`.
     """
     __tracebackhide__ = True
-    for exc in filterfalse(
-        inspect.isclass, always_iterable(expected_exception, BASE_TYPE)
-    ):
-        msg = "exceptions must be derived from BaseException, not %s"
-        raise TypeError(msg % type(exc))
+
+    if isinstance(expected_exception, type):
+        excepted_exceptions = (expected_exception,)  # type: Tuple[Type[_E], ...]
+    else:
+        excepted_exceptions = expected_exception
+    for exc in excepted_exceptions:
+        if not isinstance(exc, type) or not issubclass(exc, BaseException):
+            msg = "expected exception must be a BaseException type, not {}"
+            not_a = exc.__name__ if isinstance(exc, type) else type(exc).__name__
+            raise TypeError(msg.format(not_a))
 
     message = "DID NOT RAISE {}".format(expected_exception)
 

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -215,7 +215,10 @@ class WarningsChecker(WarningsRecorder):
     ) -> None:
         super().__init__()
 
-        self.expected_warning = validate_tup_type(expected_warning, Warning)
+        if expected_warning is None:
+            self.expected_warning = None
+        else:
+            self.expected_warning = validate_tup_type(expected_warning, Warning)
         self.match_expr = match_expr
 
     def __exit__(

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -11,9 +11,9 @@ from typing import Pattern
 from typing import Tuple
 from typing import Union
 
+from .types import validate_tup_type
 from _pytest.compat import overload
 from _pytest.compat import TYPE_CHECKING
-from .types import validate_tup_type
 from _pytest.fixtures import yield_fixture
 from _pytest.outcomes import fail
 

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -13,6 +13,7 @@ from typing import Union
 
 from _pytest.compat import overload
 from _pytest.compat import TYPE_CHECKING
+from .types import validate_tup_type
 from _pytest.fixtures import yield_fixture
 from _pytest.outcomes import fail
 
@@ -214,20 +215,7 @@ class WarningsChecker(WarningsRecorder):
     ) -> None:
         super().__init__()
 
-        msg = "exceptions must be derived from Warning, not %s"
-        if expected_warning is None:
-            expected_warning_tup = None
-        elif isinstance(expected_warning, tuple):
-            for exc in expected_warning:
-                if not issubclass(exc, Warning):
-                    raise TypeError(msg % type(exc))
-            expected_warning_tup = expected_warning
-        elif issubclass(expected_warning, Warning):
-            expected_warning_tup = (expected_warning,)
-        else:
-            raise TypeError(msg % type(expected_warning))
-
-        self.expected_warning = expected_warning_tup
+        self.expected_warning = validate_tup_type(expected_warning, Warning)
         self.match_expr = match_expr
 
     def __exit__(

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -27,7 +27,6 @@ from typing import Union
 import attr
 import pluggy
 import py.path
-from more_itertools import collapse
 from wcwidth import wcswidth
 
 import pytest
@@ -807,10 +806,15 @@ class TerminalReporter:
         )
         self._write_report_lines_from_hooks(lines)
 
-    def _write_report_lines_from_hooks(self, lines):
-        lines.reverse()
-        for line in collapse(lines):
-            self.write_line(line)
+    def _write_report_lines_from_hooks(
+        self, lines: Sequence[Union[str, Sequence[str]]]
+    ) -> None:
+        for line_or_lines in reversed(lines):
+            if isinstance(line_or_lines, str):
+                self.write_line(line_or_lines)
+            else:
+                for line in line_or_lines:
+                    self.write_line(line)
 
     @pytest.hookimpl(trylast=True)
     def pytest_report_header(self, config: Config) -> List[str]:

--- a/src/_pytest/types.py
+++ b/src/_pytest/types.py
@@ -1,9 +1,6 @@
 from .compat import TYPE_CHECKING
 
-# from more_itertools import collapse
-
 if TYPE_CHECKING:
-    from typing import Optional
     from typing import Tuple
     from typing import TypeVar
     from typing import Union

--- a/src/_pytest/types.py
+++ b/src/_pytest/types.py
@@ -24,9 +24,7 @@ def collapse_tuples(obj) -> "Tuple":
 
 def validate_tup_type(
     type_or_types: "Union[_T, Tuple[_T, ...]]", base_type: "_T"
-) -> "Optional[Tuple[_T, ...]]":
-    if type_or_types is None:
-        return None
+) -> "Tuple[_T, ...]":
     types = collapse_tuples(type_or_types)
     for exc in types:
         if not isinstance(exc, type) or not issubclass(exc, base_type):

--- a/src/_pytest/types.py
+++ b/src/_pytest/types.py
@@ -1,0 +1,39 @@
+from .compat import TYPE_CHECKING
+
+# from more_itertools import collapse
+
+if TYPE_CHECKING:
+    from typing import Optional
+    from typing import Tuple
+    from typing import TypeVar
+    from typing import Union
+
+    _T = TypeVar("_T", bound="type")
+
+
+def collapse_tuples(obj) -> "Tuple":
+    def walk(node):
+        if isinstance(node, tuple):
+            for child in node:
+                yield from walk(child)
+        else:
+            yield node
+
+    return tuple(x for x in walk(obj))
+
+
+def validate_tup_type(
+    type_or_types: "Union[_T, Tuple[_T, ...]]", base_type: "_T"
+) -> "Optional[Tuple[_T, ...]]":
+    if type_or_types is None:
+        return None
+    types = collapse_tuples(type_or_types)
+    for exc in types:
+        if not isinstance(exc, type) or not issubclass(exc, base_type):
+            raise TypeError(
+                "exceptions must be derived from {}, not {}".format(
+                    base_type.__name__,
+                    exc.__name__ if isinstance(exc, type) else type(exc).__name__,
+                )
+            )
+    return types

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -126,9 +126,19 @@ class TestRaises:
         result = testdir.runpytest()
         result.stdout.fnmatch_lines(["*2 failed*"])
 
-    def test_noclass(self):
-        with pytest.raises(TypeError):
-            pytest.raises("wrong", lambda: None)
+    def test_noclass_iterable(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match="^exceptions must be derived from BaseException, not <class 'str'>$",
+        ):
+            pytest.raises("wrong", lambda: None)  # type: ignore[call-overload]
+
+    def test_noclass_noniterable(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match="^exceptions must be derived from BaseException, not <class 'int'>$",
+        ):
+            pytest.raises(41, lambda: None)  # type: ignore[call-overload]
 
     def test_invalid_arguments_to_raises(self):
         with pytest.raises(TypeError, match="unknown"):

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -129,14 +129,14 @@ class TestRaises:
     def test_noclass_iterable(self) -> None:
         with pytest.raises(
             TypeError,
-            match="^exceptions must be derived from BaseException, not <class 'str'>$",
+            match="^exceptions must be derived from BaseException, not str$",
         ):
             pytest.raises("wrong", lambda: None)  # type: ignore[call-overload]
 
     def test_noclass_noniterable(self) -> None:
         with pytest.raises(
             TypeError,
-            match="^exceptions must be derived from BaseException, not <class 'int'>$",
+            match="^exceptions must be derived from BaseException, not int$",
         ):
             pytest.raises(41, lambda: None)  # type: ignore[call-overload]
 
@@ -295,20 +295,15 @@ class TestRaises:
         assert "Unexpected keyword arguments" in str(excinfo.value)
 
     def test_expected_exception_is_not_a_baseexception(self) -> None:
-        with pytest.raises(TypeError) as excinfo:
-            with pytest.raises("hello"):  # type: ignore[call-overload]
-                pass  # pragma: no cover
-        assert "must be a BaseException type, not str" in str(excinfo.value)
+        msg = "^exceptions must be derived from BaseException, not {}$"
+        with pytest.raises(TypeError, match=msg.format("str")):
+            pytest.raises("hello")  # type: ignore[call-overload]
 
         class NotAnException:
             pass
 
-        with pytest.raises(TypeError) as excinfo:
-            with pytest.raises(NotAnException):  # type: ignore[type-var]
-                pass  # pragma: no cover
-        assert "must be a BaseException type, not NotAnException" in str(excinfo.value)
+        with pytest.raises(TypeError, match=msg.format("NotAnException")):
+            pytest.raises(NotAnException)  # type: ignore[type-var]
 
-        with pytest.raises(TypeError) as excinfo:
-            with pytest.raises(("hello", NotAnException)):  # type: ignore[arg-type]
-                pass  # pragma: no cover
-        assert "must be a BaseException type, not str" in str(excinfo.value)
+        with pytest.raises(TypeError, match=msg.format("str")):
+            pytest.raises(("hello", NotAnException))  # type: ignore[arg-type]

--- a/testing/python/raises.py
+++ b/testing/python/raises.py
@@ -283,3 +283,22 @@ class TestRaises:
             with pytest.raises(Exception, foo="bar"):
                 pass
         assert "Unexpected keyword arguments" in str(excinfo.value)
+
+    def test_expected_exception_is_not_a_baseexception(self) -> None:
+        with pytest.raises(TypeError) as excinfo:
+            with pytest.raises("hello"):  # type: ignore[call-overload]
+                pass  # pragma: no cover
+        assert "must be a BaseException type, not str" in str(excinfo.value)
+
+        class NotAnException:
+            pass
+
+        with pytest.raises(TypeError) as excinfo:
+            with pytest.raises(NotAnException):  # type: ignore[type-var]
+                pass  # pragma: no cover
+        assert "must be a BaseException type, not NotAnException" in str(excinfo.value)
+
+        with pytest.raises(TypeError) as excinfo:
+            with pytest.raises(("hello", NotAnException)):  # type: ignore[arg-type]
+                pass  # pragma: no cover
+        assert "must be a BaseException type, not str" in str(excinfo.value)

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -53,15 +53,15 @@ class TestWarningsRecorderChecker:
     def test_typechecking(self) -> None:
         msg = "exceptions must be derived from Warning, not {}"
         with pytest.raises(TypeError, match=msg.format("int")):
-            WarningsChecker(5)
+            WarningsChecker(5)  # type: ignore[arg-type]
         with pytest.raises(TypeError, match=msg.format("str")):
-            WarningsChecker(("hi", RuntimeWarning))
+            WarningsChecker(("hi", RuntimeWarning))  # type: ignore[arg-type]
         with pytest.raises(TypeError, match=msg.format("list")):
-            WarningsChecker([DeprecationWarning, RuntimeWarning])
+            WarningsChecker([DeprecationWarning, RuntimeWarning])  # type: ignore[arg-type]
 
     def test_nested_tuples(self) -> None:
         wc1 = WarningsChecker((DeprecationWarning, RuntimeWarning))
-        wc2 = WarningsChecker(((DeprecationWarning,), (RuntimeWarning,)))
+        wc2 = WarningsChecker(((DeprecationWarning,), (RuntimeWarning,)))  # type: ignore[arg-type]
         assert wc1.expected_warning == (DeprecationWarning, RuntimeWarning)
         assert wc1.expected_warning == wc2.expected_warning
 

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -3,6 +3,7 @@ import warnings
 from typing import Optional
 
 import pytest
+from _pytest.recwarn import WarningsChecker
 from _pytest.recwarn import WarningsRecorder
 
 
@@ -50,14 +51,13 @@ class TestWarningsRecorderChecker:
             warnings.warn("test", DeprecationWarning, 2)
 
     def test_typechecking(self) -> None:
-        from _pytest.recwarn import WarningsChecker
-
-        with pytest.raises(TypeError):
-            WarningsChecker(5)  # type: ignore
-        with pytest.raises(TypeError):
-            WarningsChecker(("hi", RuntimeWarning))  # type: ignore
-        with pytest.raises(TypeError):
-            WarningsChecker([DeprecationWarning, RuntimeWarning])  # type: ignore
+        msg = "exceptions must be derived from Warning, not <class '{}'>"
+        with pytest.raises(TypeError, match=msg.format("int")):
+            WarningsChecker(5)
+        with pytest.raises(TypeError, match=msg.format("str")):
+            WarningsChecker(("hi", RuntimeWarning))
+        with pytest.raises(TypeError, match=msg.format("list")):
+            WarningsChecker([DeprecationWarning, RuntimeWarning])
 
     def test_invalid_enter_exit(self) -> None:
         # wrap this test in WarningsRecorder to ensure warning state gets reset

--- a/testing/test_recwarn.py
+++ b/testing/test_recwarn.py
@@ -51,13 +51,19 @@ class TestWarningsRecorderChecker:
             warnings.warn("test", DeprecationWarning, 2)
 
     def test_typechecking(self) -> None:
-        msg = "exceptions must be derived from Warning, not <class '{}'>"
+        msg = "exceptions must be derived from Warning, not {}"
         with pytest.raises(TypeError, match=msg.format("int")):
             WarningsChecker(5)
         with pytest.raises(TypeError, match=msg.format("str")):
             WarningsChecker(("hi", RuntimeWarning))
         with pytest.raises(TypeError, match=msg.format("list")):
             WarningsChecker([DeprecationWarning, RuntimeWarning])
+
+    def test_nested_tuples(self) -> None:
+        wc1 = WarningsChecker((DeprecationWarning, RuntimeWarning))
+        wc2 = WarningsChecker(((DeprecationWarning,), (RuntimeWarning,)))
+        assert wc1.expected_warning == (DeprecationWarning, RuntimeWarning)
+        assert wc1.expected_warning == wc2.expected_warning
 
     def test_invalid_enter_exit(self) -> None:
         # wrap this test in WarningsRecorder to ensure warning state gets reset


### PR DESCRIPTION
We barely use it; the couple places that do are not really worth the
extra dependency, I think the code is clearer without it.

Also simplifies one (regular) itertools usage.

Also improves a check and an error message in `pytest.raises`.

(cherry picked from commit 96a48f0c66ebe1ec2305c21390a3f6c059760af5)

Conflicts:
	setup.cfg
	src/_pytest/python_api.py
	src/_pytest/terminal.py