### PR TITLE
tests: drop PYTEST_REORDER_TESTS

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -9,8 +9,6 @@ environment:
   CI: "true"
   TOXENV: py37-coverage-xdist
   PYTEST_ADDOPTS: -ra --durations=50
-  # XXX: makes testing/test_pdb.py hang (with pexpect).
-  PYTEST_REORDER_TESTS: 0
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   CODECOV_TOKEN: d79f3a85-e675-4d75-8f55-3d0e4a99ebe8
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -66,44 +66,6 @@ def pytest_collection_modifyitems(items):
     slowest_items = []
     neutral_items = []
 
-    if not int(os.environ.get("PYTEST_REORDER_TESTS", 1)):
-        yield
-        return
-
-    spawn_names = {"spawn_pytest", "spawn"}
-    harder_testdir_names = {"copy_example"}
-
-    for item in items:
-        try:
-            fixtures = item.fixturenames
-        except AttributeError:
-            # doctest at least
-            # (https://github.com/pytest-dev/pytest/issues/5070)
-            neutral_items.append(item)
-        else:
-            if "testdir" in fixtures:
-                co_names = item.function.__code__.co_names
-                if spawn_names.intersection(co_names):
-                    item.add_marker(pytest.mark.uses_pexpect)
-                    slowest_items.append(item)
-                elif harder_testdir_names.intersection(co_names):
-                    # Slower to debug, e.g. with `--pdb`.
-                    item.add_marker(pytest.mark.uses_copy_example)
-                    slowest_items.append(item)
-                elif "runpytest_subprocess" in co_names:
-                    slowest_items.append(item)
-                else:
-                    slow_items.append(item)
-                item.add_marker(pytest.mark.slow)
-            else:
-                marker = item.get_closest_marker("slow")
-                if marker:
-                    slowest_items.append(item)
-                else:
-                    fast_items.append(item)
-
-    items[:] = fast_items + neutral_items + slow_items + slowest_items
-
     yield
 
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -54,21 +54,6 @@ def pytest_runtest_setup(item):
     pytest.skip("Not running {} test (use {})".format(mark, option))
 
 
-@pytest.hookimpl(hookwrapper=True, tryfirst=True)
-def pytest_collection_modifyitems(items):
-    """Prefer faster tests.
-
-    Use a hookwrapper to do this in the beginning, so e.g. --ff still works
-    correctly.
-    """
-    fast_items = []
-    slow_items = []
-    slowest_items = []
-    neutral_items = []
-
-    yield
-
-
 @pytest.fixture
 def tw_mock():
     """Returns a mock terminal writer"""

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
     coverage: coverage report -m
     coverage: coverage xml
 ignore_errors = true
-passenv = USER USERNAME COVERAGE_* PYTEST_ADDOPTS PYTEST_REORDER_TESTS TERM COLUMNS
+passenv = USER USERNAME COVERAGE_* PYTEST_ADDOPTS TERM COLUMNS
     coverage: CODECOV_* CI CI_* GITHUB_* TRAVIS TRAVIS_*
 setenv =
     _PYTEST_TOX_DEFAULT_POSARGS={env:_PYTEST_TOX_POSARGS_DOCTESTING:} {env:_PYTEST_TOX_POSARGS_LSOF:}
@@ -36,7 +36,6 @@ setenv =
     coverage: COVERAGE_FILE={toxinidir}/.coverage
 
     doctesting: _PYTEST_TOX_POSARGS_DOCTESTING=doc/en
-    grouped: PYTEST_REORDER_TESTS={env:PYTEST_REORDER_TESTS:0}
     nobyte: PYTHONDONTWRITEBYTECODE=1
     lsof: _PYTEST_TOX_POSARGS_LSOF=--lsof
     oldattrs: _PYTEST_TOX_TWISTED=twisted<20.3.0


### PR DESCRIPTION
It adds overhead/confusion and better belongs in a more generic/powerful
plugin.

TODO:

- [ ] keep it / revisit it?! ( - useful for having more annoying tests later!)